### PR TITLE
Fixed text input bug for safari

### DIFF
--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -17,6 +17,7 @@ const Input = ({
       autoFocus={autoFocus}
       placeholder={placeholder}
       value={useInternal ? state : value}
+      type='text'
       onChange={e => {
         setInternal(e.target.value)
         onChange(e.target.value)


### PR DESCRIPTION
Safari refuses to allow users to use text inputs if the type="text"
attribute is missing. This commit adds that to the search comp.